### PR TITLE
Filter out empty lines from the raw data.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -102,7 +102,11 @@ export class AppComponent {
       let colIndices = this.parseColData(rows.shift());
       let dateMap: any = {};
 
-      rows.forEach((row) => {
+      console.log(`=> Filtering out empty lines from: raw ${rows.length} rows`)
+      const validRows = rows.filter(Boolean);
+      console.log(`=> There are ${validRows.length} lines from raw data that are not empty`)
+
+      validRows.forEach((row) => {
         let rowArr = row.split('\t');
         let date = rowArr[colIndices.collection_epiweek_end];
         let failed = rowArr[colIndices.genome_status] === 'failed_sequencing';


### PR DESCRIPTION
There was an empty line at the end of the file which caused 

![](https://files.slack.com/files-pri/T0166C33N6A-F02DQS01RPB/screen_shot_2021-09-03_at_10.23.16_am.png)

This PR fixes it by filtering out all empty lines from the raw data, also logs this operation so we don't drop real data by accident.